### PR TITLE
Feat/search query

### DIFF
--- a/src/@types/Typesense.ts
+++ b/src/@types/Typesense.ts
@@ -146,3 +146,11 @@ export interface TypesenseSearchResponse {
     found?: number
   }[]
 }
+
+export interface TypesenseMultiseachCollectionSearchParams extends TypesenseSearchParams {
+  collection: string
+}
+
+export interface TypesenseMultiSearchParams {
+  searches: TypesenseMultiseachCollectionSearchParams []
+}

--- a/src/@types/Typesense.ts
+++ b/src/@types/Typesense.ts
@@ -83,7 +83,7 @@ export interface TypesenseSearchParams {
   [key: string]: any
   // From https://typesense.org/docs/latest/api/documents.html#arguments
   q: string
-  query_by: string | string[]
+  query_by: string
   query_by_weights?: string | number[]
   prefix?: string | boolean | boolean[] // default: true
   filter_by?: string
@@ -147,10 +147,14 @@ export interface TypesenseSearchResponse {
   }[]
 }
 
-export interface TypesenseMultiseachCollectionSearchParams extends TypesenseSearchParams {
-  collection: string
+export interface TypesenseMultiSearchResponse {
+  results: TypesenseSearchResponse[]
 }
 
 export interface TypesenseMultiSearchParams {
-  searches: TypesenseMultiseachCollectionSearchParams []
+  collection: string
+}
+
+export interface TypesenseMultiSearchesParam {
+  searches: TypesenseMultiSearchParams[]
 }

--- a/src/components/core/handler/queryHandler.ts
+++ b/src/components/core/handler/queryHandler.ts
@@ -19,7 +19,10 @@ export class QueryHandler extends Handler {
       return validationResponse
     }
     try {
-      const result = await this.getOceanNode().getDatabase().ddo.search(task.query)
+      let result = await this.getOceanNode().getDatabase().ddo.search(task.query)
+      if (!result) {
+        result = []
+      }
       return {
         stream: Readable.from(JSON.stringify(result)),
         status: { httpStatus: 200 }

--- a/src/components/core/handler/queryHandler.ts
+++ b/src/components/core/handler/queryHandler.ts
@@ -19,10 +19,7 @@ export class QueryHandler extends Handler {
       return validationResponse
     }
     try {
-      let result = await this.getOceanNode().getDatabase().ddo.search(task.query)
-      if (!result) {
-        result = []
-      }
+      const result = await this.getOceanNode().getDatabase().ddo.search(task.query)
       return {
         stream: Readable.from(JSON.stringify(result)),
         status: { httpStatus: 200 }

--- a/src/components/database/index.ts
+++ b/src/components/database/index.ts
@@ -11,6 +11,7 @@ import {
 import { DATABASE_LOGGER } from '../../utils/logging/common.js'
 import { validateObject } from '../core/utils/validateDdoHandler.js'
 import { ENVIRONMENT_VARIABLES } from '../../utils/constants.js'
+import {Logger} from "winston";
 
 export class OrderDatabase {
   private provider: Typesense
@@ -63,7 +64,6 @@ export class OrderDatabase {
         per_page: maxPerPage,
         page
       }
-
       const result = await this.provider
         .collections(this.schema.name)
         .documents()
@@ -407,22 +407,27 @@ export class DdoDatabase {
 
       const maxPerPage = maxResultsPerPage ? Math.min(maxResultsPerPage, 250) : 250 // Cap maxResultsPerPage at 250
       const page = pageNumber || 1 // Default to the first page if pageNumber is not provided
-      const results = []
+      // const results = []
 
-      for (const schema of this.schemas) {
-        // Extend the query with pagination parameters
-        const searchParams: TypesenseSearchParams = {
-          ...queryObj,
-          per_page: maxPerPage,
-          page
-        }
-        const result = await this.provider
-          .collections(schema.name)
-          .documents()
-          .search(searchParams)
-        results.push(result)
-      }
-
+      // for (const schema of this.schemas) {
+      //   // Extend the query with pagination parameters
+      //   const searchParams: TypesenseSearchParams = {
+      //     ...queryObj,
+      //     per_page: maxPerPage,
+      //     page
+      //   }
+      //   const result = await this.provider
+      //     .collections(schema.name)
+      //     .documents()
+      //     .search(searchParams)
+      //   results.push(result)
+      // }
+       const results = this.provider.multiSearch.search({
+            ...queryObj,
+            per_page: maxPerPage,
+            page
+          })
+      console.log(results)
       return results
     } catch (error) {
       const errorMsg =

--- a/src/components/database/typesense.ts
+++ b/src/components/database/typesense.ts
@@ -209,14 +209,6 @@ export class TypesenseMultisearch {
     searchParameters: TypesenseSearchParams,
     collections: string[]
   ): Promise<TypesenseSearchResponse[]> {
-    // const additionalQueryParams: { [key: string]: any } = {}
-    // for (const key in searchParameters) {
-    //   if (Array.isArray(searchParameters[key])) {
-    //     additionalQueryParams[key] = searchParameters[key].join(',')
-    //   }
-    // }
-    // const queryParams = Object.assign({}, searchParameters, additionalQueryParams)
-    // this.adaptQuery(searchParameters, schemas)
     const queryParams = collections.map((collection): TypesenseMultiSearchParams => {
       return {
         ...searchParameters,

--- a/src/components/database/typesense.ts
+++ b/src/components/database/typesense.ts
@@ -161,6 +161,32 @@ export class TypesenseCollections {
   }
 }
 
+export class TypesenseMultisearch {
+  private readonly apiPath = '/multi_search'
+  private readonly api: TypesenseApi
+
+  constructor(api: TypesenseApi) {
+    this.api = api
+  }
+
+  async search(
+    searchParameters: TypesenseSearchParams,
+    collections: string[]
+  ): Promise<TypesenseSearchResponse[]> {
+    const queryParams = collections.map((collection): TypesenseMultiSearchParams => {
+      return {
+        ...searchParameters,
+        collection
+      }
+    })
+
+    const response = await this.api.post<TypesenseMultiSearchResponse>(this.apiPath, {
+      searches: queryParams
+    })
+    return response.results.filter((r) => r.hits)
+  }
+}
+
 /**
  * Typesense class is used to create a base instance to work with Typesense
  * It initiates classes that provides access to methods of collections
@@ -194,31 +220,5 @@ export class Typesense {
       }
       return this.collectionsRecords[collectionName]
     }
-  }
-}
-
-export class TypesenseMultisearch {
-  private readonly apiPath = '/multi_search'
-  private readonly api: TypesenseApi
-
-  constructor(api: TypesenseApi) {
-    this.api = api
-  }
-
-  async search(
-    searchParameters: TypesenseSearchParams,
-    collections: string[]
-  ): Promise<TypesenseSearchResponse[]> {
-    const queryParams = collections.map((collection): TypesenseMultiSearchParams => {
-      return {
-        ...searchParameters,
-        collection
-      }
-    })
-
-    const response = await this.api.post<TypesenseMultiSearchResponse>(this.apiPath, {
-      searches: queryParams
-    })
-    return response.results.filter((r) => r.hits)
   }
 }

--- a/src/components/database/typesense.ts
+++ b/src/components/database/typesense.ts
@@ -169,11 +169,14 @@ export class Typesense {
   api: TypesenseApi
   collectionsRecords: Record<string, TypesenseCollection> = {}
   private readonly _collections: TypesenseCollections
+  readonly multiSearch: TypesenseMultisearch;
 
   constructor(options: TypesenseConfigOptions) {
     this.config = new TypesenseConfig(options)
     this.api = new TypesenseApi(this.config)
     this._collections = new TypesenseCollections(this.api)
+    this.multiSearch = new TypesenseMultisearch(this.api)
+
   }
 
   collections(): TypesenseCollections
@@ -190,5 +193,25 @@ export class Typesense {
       }
       return this.collectionsRecords[collectionName]
     }
+  }
+}
+
+export class TypesenseMultisearch {
+  private readonly apiPath = 'multi_search'
+
+  constructor(private readonly api: TypesenseApi) {}
+
+  search(searchParameters: TypesenseSearchParams) {
+    const additionalQueryParams: { [key: string]: any } = {}
+    for (const key in searchParameters) {
+      if (Array.isArray(searchParameters[key])) {
+        additionalQueryParams[key] = searchParameters[key].join(',')
+      }
+    }
+    const queryParams = Object.assign({}, searchParameters, additionalQueryParams)
+    return this.api.post<TypesenseSearchResponse>(
+        this.apiPath,
+        queryParams
+    ) as Promise<TypesenseSearchResponse>
   }
 }


### PR DESCRIPTION
- use `multi_search` in typesense
- sort_by published/price doesn't work in the current schemas. The following fields must by set as numeric: stats.price.value, nft.created (maybe have something like nft.createdTimestamp)
- to sort by relevance, the ddos must have set `_score` filed. Otherwise the request will fail.
